### PR TITLE
implemented MonadLogic

### DIFF
--- a/Control/Monad/Stream.hs
+++ b/Control/Monad/Stream.hs
@@ -24,7 +24,8 @@
 -- are interpreted as a multiset, i.e., a valid transformation
 -- according to the monad laws may change the order of the results.
 -- 
-module Control.Monad.Stream ( Stream, suspended, runStream ) where
+module Control.Monad.Stream ( Stream, suspended, runStream, 
+                              runL, ifte, once, cut ) where
 
 import Control.Monad
 import Control.Applicative
@@ -57,6 +58,56 @@ runStream Nil         = []
 runStream (Single x)  = [x]
 runStream (Cons x xs) = x : runStream xs
 runStream (Susp xs)   = runStream xs
+
+msplit :: Stream a -> Maybe (a, Stream a)
+msplit Nil = Nothing
+msplit (Single a) = Just (a, Nil)
+msplit (Cons a r) = Just (a, r)
+msplit (Susp i) = msplit i
+
+-- |
+-- The function @runL@ enumerates the results of a
+-- non-deterministic computation, limited by an optional count.
+-- 
+runL :: Maybe Int -> Stream a -> [a]
+runL Nothing m = case msplit m of
+  Nothing -> []
+  Just (a, r) -> a:runL Nothing r
+runL (Just i) _ | i == 0 = []
+runL (Just i) m = case msplit m of
+  Nothing -> []
+  Just (a, r) -> a:runL (Just (i-1)) r
+
+-- | 
+-- The function @ifte t th el@ is the logical conditional operator,
+-- equivalent to Prolog's "soft-cut". First the computation @t@ is
+-- executed. If it succeeds with at least one result, the entire
+-- @ifte@ computation is equivalent to @t >>= th@. Otherwise, the
+-- entire computation becomes equivalent to @el@.
+--
+ifte :: Stream a -> (a -> Stream b) -> Stream b -> Stream b
+ifte t th el = case msplit t of 
+  Nothing -> el
+  Just (a, r) -> th a `mplus` (r >>= th)
+
+-- | 
+-- The function @once@ selects one solution out of possibly
+-- many. It greatly improves efficiency as it can be used to avoid
+-- useless backtracking and therefore to dispose of data structures
+-- that hold information needed for backtracking (e.g., choice
+-- points).
+--
+once :: Stream a -> Stream a
+once m = case msplit m of
+  Nothing -> mzero
+  Just (a, _) -> return a
+
+-- |
+-- The function @cut@ implements “negation as failure” and is
+-- equivalent to "cut" in Prolog.
+--
+cut :: Stream a -> Stream ()
+cut m = ifte (once m) (const mzero) (return ())
 
 instance Monad Stream
  where

--- a/Control/Monad/Stream.hs
+++ b/Control/Monad/Stream.hs
@@ -102,39 +102,10 @@ instance MonadLogic Stream where
    (>>-) = (>>=)
    interleave = mplus
 
-   -- |
-   -- The function @msplit@ splits a non-empty stream into a head and tail.
-   --
    msplit Nil = return Nothing
    msplit (Single a) = return $ Just (a, Nil)
-   msplit (Cons a r) = return $ Just (a, r)
-   msplit (Susp i) = msplit i
-
-   -- | 
-   -- The function @ifte t th el@ is the logical conditional operator,
-   -- equivalent to Prolog's "soft-cut". First the computation @t@ is
-   -- executed. If it succeeds with at least one result, the entire
-   -- @ifte@ computation is equivalent to @t >>= th@. Otherwise, the
-   -- entire computation becomes equivalent to @el@.
-   --
-   ifte t th el = do 
-     s <- msplit t
-     case s of
-       Nothing -> el
-       Just (a, r) -> th a `mplus` (r >>= th)
-
-   -- | 
-   -- The function @once@ selects one solution out of possibly
-   -- many. It greatly improves efficiency as it can be used to avoid
-   -- useless backtracking and therefore to dispose of data structures
-   -- that hold information needed for backtracking (e.g., choice
-   -- points).
-   --
-   once m = do
-     s <- msplit m
-     case s of
-       Nothing -> mzero
-       Just (a, _) -> return a
+   msplit (Cons a r) = return $ Just (a, suspended r)
+   msplit (Susp i) = suspended $ msplit i
 
 instance Foldable Stream where
   foldMap _ Nil = mempty

--- a/Control/Monad/Stream.hs
+++ b/Control/Monad/Stream.hs
@@ -29,6 +29,10 @@ module Control.Monad.Stream ( Stream, suspended, runStream ) where
 import Control.Monad
 import Control.Applicative
 import Control.Monad.Logic
+import Data.Foldable
+import Data.Monoid
+import Data.Traversable
+import Prelude hiding (foldr)
 
 -- |
 -- Results of non-deterministic computations of type @Stream a@ can be
@@ -131,3 +135,15 @@ instance MonadLogic Stream where
      case s of
        Nothing -> mzero
        Just (a, _) -> return a
+
+instance Foldable Stream where
+  foldMap _ Nil = mempty
+  foldMap f (Single a) = f a
+  foldMap f (Cons a r) = f a `mappend` foldMap f r
+  foldMap f (Susp i) = foldMap f i
+
+instance Traversable Stream where
+  traverse _ Nil = pure Nil
+  traverse f (Single a) = Single <$> f a
+  traverse f (Cons a r) = Cons <$> f a <*> traverse f r
+  traverse f (Susp i) = Susp <$> traverse f i

--- a/Control/Monad/Stream.hs
+++ b/Control/Monad/Stream.hs
@@ -25,10 +25,11 @@
 -- according to the monad laws may change the order of the results.
 -- 
 module Control.Monad.Stream ( Stream, suspended, runStream, 
-                              runL, ifte, once, cut ) where
+                              runL, msplit, ifte, once, cut ) where
 
 import Control.Monad
 import Control.Applicative
+import Prelude hiding (head, tail)
 
 -- |
 -- Results of non-deterministic computations of type @Stream a@ can be
@@ -59,6 +60,9 @@ runStream (Single x)  = [x]
 runStream (Cons x xs) = x : runStream xs
 runStream (Susp xs)   = runStream xs
 
+-- |
+-- The function @msplit@ splits a non-empty stream into a head and tail.
+--
 msplit :: Stream a -> Maybe (a, Stream a)
 msplit Nil = Nothing
 msplit (Single a) = Just (a, Nil)

--- a/Control/Monad/Stream.hs
+++ b/Control/Monad/Stream.hs
@@ -24,12 +24,11 @@
 -- are interpreted as a multiset, i.e., a valid transformation
 -- according to the monad laws may change the order of the results.
 -- 
-module Control.Monad.Stream ( Stream, suspended, runStream, 
-                              runL, msplit, ifte, once, cut ) where
+module Control.Monad.Stream ( Stream, suspended, runStream ) where
 
 import Control.Monad
 import Control.Applicative
-import Prelude hiding (head, tail)
+import Control.Monad.Logic
 
 -- |
 -- Results of non-deterministic computations of type @Stream a@ can be
@@ -59,59 +58,6 @@ runStream Nil         = []
 runStream (Single x)  = [x]
 runStream (Cons x xs) = x : runStream xs
 runStream (Susp xs)   = runStream xs
-
--- |
--- The function @msplit@ splits a non-empty stream into a head and tail.
---
-msplit :: Stream a -> Maybe (a, Stream a)
-msplit Nil = Nothing
-msplit (Single a) = Just (a, Nil)
-msplit (Cons a r) = Just (a, r)
-msplit (Susp i) = msplit i
-
--- |
--- The function @runL@ enumerates the results of a
--- non-deterministic computation, limited by an optional count.
--- 
-runL :: Maybe Int -> Stream a -> [a]
-runL Nothing m = case msplit m of
-  Nothing -> []
-  Just (a, r) -> a:runL Nothing r
-runL (Just i) _ | i == 0 = []
-runL (Just i) m = case msplit m of
-  Nothing -> []
-  Just (a, r) -> a:runL (Just (i-1)) r
-
--- | 
--- The function @ifte t th el@ is the logical conditional operator,
--- equivalent to Prolog's "soft-cut". First the computation @t@ is
--- executed. If it succeeds with at least one result, the entire
--- @ifte@ computation is equivalent to @t >>= th@. Otherwise, the
--- entire computation becomes equivalent to @el@.
---
-ifte :: Stream a -> (a -> Stream b) -> Stream b -> Stream b
-ifte t th el = case msplit t of 
-  Nothing -> el
-  Just (a, r) -> th a `mplus` (r >>= th)
-
--- | 
--- The function @once@ selects one solution out of possibly
--- many. It greatly improves efficiency as it can be used to avoid
--- useless backtracking and therefore to dispose of data structures
--- that hold information needed for backtracking (e.g., choice
--- points).
---
-once :: Stream a -> Stream a
-once m = case msplit m of
-  Nothing -> mzero
-  Just (a, _) -> return a
-
--- |
--- The function @cut@ implements “negation as failure” and is
--- equivalent to "cut" in Prolog.
---
-cut :: Stream a -> Stream ()
-cut m = ifte (once m) (const mzero) (return ())
 
 instance Monad Stream
  where
@@ -147,3 +93,41 @@ instance Applicative Stream where
 instance Alternative Stream where
   empty = Nil
   (<|>) = mplus
+
+instance MonadLogic Stream where
+   (>>-) = (>>=)
+   interleave = mplus
+
+   -- |
+   -- The function @msplit@ splits a non-empty stream into a head and tail.
+   --
+   msplit Nil = return Nothing
+   msplit (Single a) = return $ Just (a, Nil)
+   msplit (Cons a r) = return $ Just (a, r)
+   msplit (Susp i) = msplit i
+
+   -- | 
+   -- The function @ifte t th el@ is the logical conditional operator,
+   -- equivalent to Prolog's "soft-cut". First the computation @t@ is
+   -- executed. If it succeeds with at least one result, the entire
+   -- @ifte@ computation is equivalent to @t >>= th@. Otherwise, the
+   -- entire computation becomes equivalent to @el@.
+   --
+   ifte t th el = do 
+     s <- msplit t
+     case s of
+       Nothing -> el
+       Just (a, r) -> th a `mplus` (r >>= th)
+
+   -- | 
+   -- The function @once@ selects one solution out of possibly
+   -- many. It greatly improves efficiency as it can be used to avoid
+   -- useless backtracking and therefore to dispose of data structures
+   -- that hold information needed for backtracking (e.g., choice
+   -- points).
+   --
+   once m = do
+     s <- msplit m
+     case s of
+       Nothing -> mzero
+       Just (a, _) -> return a

--- a/stream-monad.cabal
+++ b/stream-monad.cabal
@@ -21,7 +21,8 @@ Stability:     experimental
 Extra-Source-Files: README
 
 Library
-  Build-Depends:    base >= 3 && < 5
+  Build-Depends:    base >= 3 && < 5,
+                    logict
   Exposed-Modules:  Control.Monad.Stream
   Ghc-Options:      -Wall
 


### PR DESCRIPTION
Here's the implementation of MonadLogic. I've removed runL (since it's redundant), and cut (since it's trivial to implement in terms of the other ops). 

Warren
