### PR TITLE
Bump logict version

### DIFF
--- a/stream-monad.cabal
+++ b/stream-monad.cabal
@@ -22,7 +22,7 @@ Extra-Source-Files: README
 
 Library
   Build-Depends:    base >= 3 && < 5,
-                    logict >= 0.4 && < 0.6
+                    logict >= 0.4 && < 0.7
   HS-Source-Dirs:   src
   Exposed-Modules:  Control.Monad.Stream
   Ghc-Options:      -Wall


### PR DESCRIPTION
In order to be able to build with newer GHC versions.

logict < 0.6 depends on base (>=2 && <4.12)
logict < 0.7 depends on base (>=2 && <5)
